### PR TITLE
🐛 Swap Quote types for duckdb import

### DIFF
--- a/src/dbt_pipeline_utils/p_utils/structures/inc_structure.py
+++ b/src/dbt_pipeline_utils/p_utils/structures/inc_structure.py
@@ -359,7 +359,7 @@ class IncStructureSC(StructureBC):
 
             dbt_tablename = normalize_name(df, trailing=False, extension="drop")
 
-            args = f'{{fq_tablename: "{dbt_tablename}", csv_path: "{raw_data_csv_path}"}}'
+            args = f"{{fq_tablename: '{dbt_tablename}', csv_path: '{raw_data_csv_path}'}}"
 
             importer.import_data(dbt_tablename, args)
 


### PR DESCRIPTION
Per https://discourse.getdbt.com/t/confused-with-cli-vars-syntax/12355/2 , I swapped the inner and outer quote types. This seems to work fine on my windows machine. 

⚠️ I did not test on other systems!